### PR TITLE
Adding command line useability improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+numpy-stl
+argparse


### PR DESCRIPTION
# Added

- Added `requirements.txt` to allow end users to install all dependencies using `pip install -r requirements.txt`
- Added checking if input file is correct type (.stl/.gcode)
- Added check for output folder and if it does not exist and attempt to create it before running transformation
- Added printout of the transformation 'settings' before running
- Added option to recognize transform options (angle, direction) from the .gcode file name
- Added help section. Each script can be run with `-h` to list available options and their description

# Modified
- Modified script to use `argparse` and accept command line arguments
- Script now accepts command line arguments to specify input file, output file, direction, angle etc.


# How to install script dependencies
Run `pip install -r requirements.txt` (assuming you have Python and PIP installed)

# How to run the script
## Transform
Transform `input.stl` STL file and save output to `transformed` folder. Use angle of 16 degrees and run 1 iteration. Default is `outward` transformation.

Example: 
`Transformation_STL_var_angle.py --file input.stl --output transformed --angle 16 --iterations 1` 

## Back transform GCode
Back transform `test_transformed_outward_16deg_0.8n_0.55mm_PETG_MK3S_32m.gcode` and save to `transformed` folder. Use filename to detect transformation parameters.

Example: 
`Transformation_STL_var_angle.py --file test_transformed_outward_16deg_0.8n_0.55mm_PETG_MK3S_32m.gcode --output transformed` 

Alternatively you could also specify angle and direction via command line parameters.