### PR TITLE
Add argparse arguments to Scripts for Variable Angle

### DIFF
--- a/Scripts for Variable Angle/Backtransformation_GCode_var_angle.py
+++ b/Scripts for Variable Angle/Backtransformation_GCode_var_angle.py
@@ -13,7 +13,7 @@ def main():
 
 
 def parseArgs():
-    parser = argparse.ArgumentParser(description='Transform STL 3D models for conical slicing.')
+    parser = argparse.ArgumentParser(description='Backtransforms gcode file generated from a transformed STL.')
 
     DEF_ANGLE = 16.0
     DEF_CONE_TYPE = 'outward'

--- a/Scripts for Variable Angle/Backtransformation_GCode_var_angle.py
+++ b/Scripts for Variable Angle/Backtransformation_GCode_var_angle.py
@@ -1,4 +1,3 @@
-import re
 import numpy as np
 import time
 import argparse


### PR DESCRIPTION
This PR adds argparse arguments instead of changing constants in the scripts all the time. Some constants can still be changed as default arguments for argparse.

This also adds a __name__ == '__main__' check for good form and puts the main code up top to make it more readable.

It also adds some type hints.

Other minor changes, like replacing a german name with an english one.